### PR TITLE
Allow lookaround in regexes

### DIFF
--- a/trial_identifier_search.R
+++ b/trial_identifier_search.R
@@ -77,7 +77,8 @@ run_trial_identifier_search <- function(folder, save_file) {
                 
                 text <- readChar(filename, file.info(filename)$size)
                 
-                idmatches <- regmatches(text, gregexpr(identifier[2], text))
+                # Allow lookaround in regexes
+                idmatches <- regmatches(text, gregexpr(identifier[2], text, perl = TRUE))
                 
                 if (length(idmatches[[1]]) > 0) {
                     


### PR DESCRIPTION
Hi @bgcarlisle ! Here's the change I mentioned via email. This should resolve the bug with the EUCTR regex which includes lookarounds